### PR TITLE
Improve Java main arg parsing

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -8,7 +8,8 @@
         org.clojure/java.classpath {:mvn/version "1.0.0"}
         org.clojure/tools.cli {:mvn/version "1.0.206"}
         org.clojure/tools.logging {:mvn/version "1.2.4"}
-        nrepl/nrepl {:mvn/version "1.0.0"}}
+        nrepl/nrepl {:mvn/version "1.0.0"}
+        instaparse/instaparse {:mvn/version "1.4.12"}}
  :mvn/repos
  {"confluent" {:url "https://packages.confluent.io/maven/"}}
  :aliases

--- a/src/us/jeffevans/kc_repl/java_main.clj
+++ b/src/us/jeffevans/kc_repl/java_main.clj
@@ -3,27 +3,69 @@
             [clojure.tools.cli :as cli]
             [clojure.tools.logging :as log]
             [us.jeffevans.kc-repl :as kcr]
-            [us.jeffevans.kc-repl.type-handler-load :as thl])
-  (:gen-class :name us.jeffevans.KcRepl)
-  (:import (org.apache.logging.log4j.core.config Configurator)))
-
-(def cli-options
-  ;; An option with a required argument
-  [["-p" "--port PORT" "Port number"
-    :default 80
-    :parse-fn #(Integer/parseInt %)
-    :validate [#(< 0 % 0x10000) "Must be a number between 0 and 65536"]]
-   ;; A non-idempotent option (:default is applied first)
-   ["-v" nil "Verbosity level"
-    :id :verbosity
-    :default 0
-    :update-fn inc] ; Prior to 0.4.1, you would have to use:
-   ;; :assoc-fn (fn [m k _] (update-in m [k] inc))
-   ;; A boolean option defaulting to nil
-   ["-h" "--help"]])
+            [us.jeffevans.kc-repl.type-handler-load :as thl]
+            [instaparse.core :as insta])
+  (:gen-class :name us.jeffevans.KcRepl))
 
 (defn- get-input-line []
   (read-line))
+
+(def java-cmd-args
+  (insta/parser
+    "<S> = CMD_NAME <WHITESPACE?> (SHORT_ARG | LONG_ARG)*
+     CMD_NAME = #'[a-zA-Z][\\-_\\+a-zA-Z0-9]*'
+     BAREWORD = #'[a-zA-Z0-9][\\-_\\+a-zA-Z0-9]*'
+     ARG_PARAM = (SINGLE_QUOTED_WORD | DOUBLE_QUOTED_WORD | BAREWORD)
+     LONG_ARG_WORD = <'-'> <'-'> BAREWORD
+     LONG_ARG = LONG_ARG_WORD <WHITESPACE?> (ARG_PARAM <WHITESPACE?>)*
+     SHORT_ARG_WORD = <'-'> BAREWORD
+     SHORT_ARG = SHORT_ARG_WORD <WHITESPACE?> (ARG_PARAM <WHITESPACE?>)*
+     WHITESPACE = #'\\s+'
+     SINGLE_QUOTED_WORD = <'\\''> (ANY_WORD <WHITESPACE?>)* <'\\''>
+     DOUBLE_QUOTED_WORD = <'\\\"'> (ANY_WORD <WHITESPACE?>)* <'\\\"'>
+     <ANY_WORD> = #'[\\-_a-zA-Z0-9]+'"))
+
+(defn- quoted-word->vals [quoted-word]
+  (str/join " " quoted-word))
+
+(defn- arg->vals [[arg-kind [_ arg-nm]] & arg-prms]
+  (let [arg-nm-str (case arg-kind
+                     :CMD_NAME arg-nm
+                     :LONG_ARG_WORD (format "--%s" arg-nm)
+                     :SHORT_ARG_WORD (format "-%s" arg-nm))]
+    (if (nil? arg-prms)
+      {arg-nm-str []}
+      (reduce (fn [acc [_ [arg-type & more]]]
+                (let [reduced-arg (case arg-type
+                                    :BAREWORD
+                                    (first more)
+
+                                    (:DOUBLE_QUOTED_WORD :SINGLE_QUOTED_WORD)
+                                    (quoted-word->vals more))]
+                  (-> (update acc arg-nm-str #(or % []))
+                      (update arg-nm-str conj reduced-arg))))
+              {}
+              arg-prms))))
+(defn parse-and-transform-input-line [input-line]
+  (let [arg-maps (insta/transform {:CMD_NAME (fn [cmd-nm]
+                                               {::command-name cmd-nm})
+                                   :SHORT_ARG arg->vals
+                                   :LONG_ARG arg->vals}
+                                  (java-cmd-args input-line))]
+    (let [merged-args (apply merge arg-maps)
+          cmd-nm      (::command-name merged-args)]
+      [cmd-nm (dissoc merged-args ::command-name)])))
+(defn- constant-seq [value]
+  (cycle (repeat 1 value)))
+
+(defn parse-line-as-cli-args [input-line]
+  (let [[cmd-nm parsed-args] (parse-and-transform-input-line input-line)]
+    (reduce-kv (fn [acc arg-nm arg-vals]
+                 (if (empty? arg-vals)
+                   (conj acc arg-nm)
+                   (vec (concat acc (interleave (constant-seq arg-nm) arg-vals)))))
+               [cmd-nm]
+               parsed-args)))
 
 (defn -main
   "Entrypoint for the uberjar (Java) main.
@@ -38,7 +80,7 @@
       (let [continue? (atom true)]
         (while @continue?
           (let [input       (get-input-line)
-                [op & args] (if (nil? input) ["stop"] (str/split input #" "))
+                [op & args] (if (nil? input) ["stop"] (parse-line-as-cli-args input))
                 {:keys [::kcr/invoke-fn ::kcr/opts-spec ::kcr/print-offsets?]} (get @#'kcr/java-cmds op)]
             (log/tracef "got input %s, op %s, args %s, opts-spec %s" input op (pr-str args) (pr-str opts-spec))
             (println)

--- a/test/us/jeffevans/kc_repl/java_main_arg_parse_test.clj
+++ b/test/us/jeffevans/kc_repl/java_main_arg_parse_test.clj
@@ -1,0 +1,37 @@
+(ns us.jeffevans.kc-repl.java-main-arg-parse-test
+  "Tests for Java main arg parsing, both the instaparse grammar and conversion to tools.cli args"
+  (:require [clojure.test :refer :all]
+            [us.jeffevans.kc-repl.java-main :as kcrm]))
+
+(deftest arg-parse-test
+  (let [cases [["dostuff -f a --bar \"baz man\" --zen a b c d"
+                ["dostuff" {"-f" ["a"]
+                            "--bar" ["baz man"]
+                            "--zen" ["a" "b" "c" "d"]}]]
+               ["domorestuff -a a \"b c\" d -e -f \"gh -i\" j"
+                ["domorestuff" {
+                                "-a" ["a"
+                                      "b c"
+                                      "d"]
+                                "-e" []
+                                "-f" ["gh -i"
+                                      "j"]}]]
+               ["read-from --topic test-topic --part 0 --offset 0 --num-msg 1 --record-handling-opts json"
+                ["read-from" {"--topic" ["test-topic"]
+                              "--part" ["0"]
+                              "--offset" ["0"]
+                              "--num-msg" ["1"]
+                              "--record-handling-opts" ["json"]}]]
+               ["seek+ --by 2"
+                ["seek+" {"--by" ["2"]}]]]]
+    (doseq [[input-ln exp-map] cases]
+      (let [parse-res (kcrm/parse-and-transform-input-line input-ln)]
+        (is (= exp-map parse-res))))))
+
+(deftest build-tools-cli-args-test
+  (let [cases [["foo -a b c --d --e f g -h i"
+                ["foo" "-a" "b" "-a" "c" "--d" "--e" "f" "--e" "g" "-h" "i"]]]]
+    (doseq [[input-ln exp-args] cases]
+      (let [args-res (kcrm/parse-line-as-cli-args input-ln)]
+        (is (= exp-args args-res))))))
+


### PR DESCRIPTION
- Adopt [instaparse](https://github.com/Engelberg/instaparse) to generate a grammar for the Java command line args
- Use instaparse transformation functions to get the arg values out, grouped by arg name
- Add various test cases for the arg parsing functions
- Update Java main to use the new arg parsing