### PR TITLE
Fix project structure after refacto

### DIFF
--- a/type-handlers/avro/deps.edn
+++ b/type-handlers/avro/deps.edn
@@ -26,7 +26,7 @@
                       org.clojure/test.check {:mvn/version "1.1.1"}
                       io.github.cognitect-labs/test-runner
                       {:git/tag "v0.5.0" :git/sha "48c3c67"}
-                      us.jeffevans/kc-repl$tests {:local/root "../.." :classifier "tests"}}
+                      us.jeffevans/kc-repl {:local/root "../.."}}
          :main-opts ["-m" "cognitect.test-runner"]
          :exec-fn cognitect.test-runner.api/test}}}
 

--- a/type-handlers/protobuf/deps.edn
+++ b/type-handlers/protobuf/deps.edn
@@ -26,7 +26,8 @@
   :test {:extra-paths ["test" "test-java" "target/classes"]
          :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
                       io.github.cognitect-labs/test-runner
-                      {:git/tag "v0.5.0" :git/sha "48c3c67"}}
+                      {:git/tag "v0.5.0" :git/sha "48c3c67"}
+                      us.jeffevans/kc-repl {:local/root "../.."}}
          :main-opts ["-m" "cognitect.test-runner"]
          :exec-fn cognitect.test-runner.api/test}}}
 


### PR DESCRIPTION
Add the root project under `:tests` alias too.  This is a follow-up from #19.