### PR TITLE
Switch from build-clj library to using tools.build api instead

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -2,9 +2,11 @@
 
 for s in "avro" "protobuf"; do
   pushd type-handlers/$s
-  clojure -J-Dclojure.core.async.pool-size=1 -T:build ci '{:aliases [:test-dependencies :type-handlers]}'
+  echo "running tests and building uberjar for $s type handler"
+  clj -T:build:test:test-dependencies run-tests && clj -T:build uberjar
   popd
 done
 
-clojure -J-Dclojure.core.async.pool-size=1 -T:build ci '{:aliases [:test-dependencies :type-handlers]}'
+echo "running tests and building uberjar for kc-repl main"
+clj -T:build:test:type-handlers:test-dependencies run-tests && clj -T:build:type-handlers uberjar
 

--- a/deps.edn
+++ b/deps.edn
@@ -16,11 +16,8 @@
  :aliases
  {:run {:main-opts ["-m" "us.jeffevans.kc-repl"]
         :jvm-opts ["-Dclojure.core.async.pool-size=1"]}
-  :build {:deps {io.github.seancorfield/build-clj
-                 {:git/tag "v0.9.2" :git/sha "9c9f078"
-                  ;; since we're building an app uberjar, we do not
-                  ;; need deps-deploy for clojars.org deployment:
-                  :deps/root "slim"}}
+  :build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.0"
+                                                :git/sha "3a2c484"}}
           :ns-default build}
   :type-handlers {:extra-deps {us.jeffevans.kc-repl/avro-handler {:local/root "type-handlers/avro"}
                                us.jeffevans.kc-repl/protobuf-handler {:local/root "type-handlers/protobuf"}}

--- a/test-common/deps.edn
+++ b/test-common/deps.edn
@@ -15,11 +15,8 @@
  :aliases
  {:run {:main-opts ["-m" "us.jeffevans.kc-repl"]
         :jvm-opts ["-Dclojure.core.async.pool-size=1"]}
-  :build {:deps {io.github.seancorfield/build-clj
-                 {:git/tag "v0.9.2" :git/sha "9c9f078"
-                  ;; since we're building an app uberjar, we do not
-                  ;; need deps-deploy for clojars.org deployment:
-                  :deps/root "slim"}}
+  :build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.0"
+                                                :git/sha "3a2c484"}}
           :ns-default build}
   :test-dependencies {:extra-paths ["test"
                                     "type-handlers/avro/test-resources"

--- a/type-handlers/avro/build.clj
+++ b/type-handlers/avro/build.clj
@@ -1,28 +1,42 @@
 (ns build
-  (:refer-clojure :exclude [test])
-  (:require [org.corfield.build :as bb]))
+  (:require [clojure.tools.build.api :as b]))
 
 (def lib 'net.clojars.jeff_evans/kc-repl-type-handler-avro)
-(def version "1.1.0")
+(def version (format "1.1.%s" (b/git-count-revs nil)))
+(def class-dir "target/classes")
+(def src-jar-file (format "target/%s-%s-avro-handler-src.jar" (name lib) version))
+(def uberjar-file (format "target/%s-%s-avro-handler.jar" (name lib) version))
+(def basis (delay (b/create-basis {:project "deps.edn"})))
 
-(defn test "Run the tests." [opts]
-  (bb/run-tests opts))
+(defn clean [_]
+      (b/delete {:path "target"}))
 
-(defn print-classpath []
-  (let [classpath (System/getProperty "java.class.path")]
-    (println "Current CLASSPATH:")
-    (println classpath)))
+(defn jar [_]
+      (b/write-pom {:class-dir class-dir
+                    :lib lib
+                    :version version
+                    :basis @basis
+                    :src-dirs ["src"]})
+      (b/copy-dir {:src-dirs ["src" "resources"]
+                   :target-dir class-dir})
+      (b/jar {:class-dir class-dir
+              :jar-file  src-jar-file}))
 
+(defn uberjar [_]
+      (clean nil)
+      (b/copy-dir {:src-dirs ["src" "resources"]
+                   :target-dir class-dir})
+      (b/compile-clj {:basis @basis
+                      :class-dir class-dir})
+      (b/uber {:class-dir class-dir
+               :uber-file uberjar-file
+               :basis @basis}))
 
-(defn ci "Run the CI pipeline of tests (and build the uberjar)." [opts]
-  (-> opts
-      (assoc :lib lib :version version :transitive true)
-      (bb/run-tests)
-      (bb/clean)
-      (bb/uber)))
-
-(defn uberjar "Just build the uberjar" [opts]
-      (-> opts
-          (assoc :lib lib :version version)
-          (bb/clean)
-          (bb/uber)))
+(defn run-tests [_]
+  (b/copy-dir {:src-dirs ["resources"]
+               :target-dir class-dir})
+  (b/compile-clj {:basis @basis
+                  :class-dir class-dir})
+  (let [{:keys [exit] :as res} (b/process {:command-args ["clj" "-M:test:test-dependencies"]})]
+    (when-not (zero? exit)
+      (throw (ex-info (str "run-tests failed") res)))))

--- a/type-handlers/avro/deps.edn
+++ b/type-handlers/avro/deps.edn
@@ -1,14 +1,12 @@
 {:paths ["src" "resources"]
  :deps {io.confluent/kafka-avro-serializer {:mvn/version "7.2.1"}
-        us.jeffevans.kc-repl/type-handlers {:local/root ".."}}
+        us.jeffevans.kc-repl/type-handlers {:local/root ".."}
+        org.clojure/tools.logging {:mvn/version "1.3.0"}}
  :mvn/repos
  {"confluent" {:url "https://packages.confluent.io/maven/"}}
  :aliases
- {:build {:deps {io.github.seancorfield/build-clj
-                 {:git/tag "v0.9.2" :git/sha "9c9f078"
-                  ;; since we're building an app uberjar, we do not
-                  ;; need deps-deploy for clojars.org deployment:
-                  :deps/root "slim"}}
+ {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.0"
+                                                :git/sha "3a2c484"}}
           :ns-default build}
   :test-dependencies {:extra-paths ["test" "test-resources"]
                       :extra-deps {org.testcontainers/testcontainers {:mvn/version "1.19.4"}

--- a/type-handlers/protobuf/deps.edn
+++ b/type-handlers/protobuf/deps.edn
@@ -1,16 +1,13 @@
 {:paths ["src" "resources"]
  :deps {io.confluent/kafka-protobuf-serializer {:mvn/version "7.5.1"}
         com.google.protobuf/protobuf-java {:mvn/version "3.19.6"}
+        org.clojure/tools.logging {:mvn/version "1.3.0"}
         us.jeffevans.kc-repl/type-handlers {:local/root ".."}}
  :mvn/repos
  {"confluent" {:url "https://packages.confluent.io/maven/"}}
  :aliases
- {:build {:deps {io.github.seancorfield/build-clj
-                 {:git/tag "v0.9.2" :git/sha "9c9f078"
-                  ;; since we're building an app uberjar, we do not
-                  ;; need deps-deploy for clojars.org deployment:
-                  :deps/root "slim"}
-                 io.github.clojure/tools.build {:git/tag "v0.9.6" :git/sha "8e78bcc"}}
+ {:build {:deps {io.github.clojure/tools.build {:git/tag "v0.10.0"
+                                                :git/sha "3a2c484"}}
           :ns-default build}
   :test-dependencies {:extra-paths ["test-resources"]
                       :extra-deps {org.testcontainers/testcontainers {:mvn/version "1.19.4"}


### PR DESCRIPTION
Fix some deps issues in the various submodules

Add an implementation of run-tests that simply forks clj to do it

Update build-all.sh script to do the new stuff

Fixes #13.