### PR TITLE
Demo bugfixes

### DIFF
--- a/src/us/jeffevans/kc_repl/java_main.clj
+++ b/src/us/jeffevans/kc_repl/java_main.clj
@@ -5,7 +5,7 @@
             [us.jeffevans.kc-repl :as kcr]
             [us.jeffevans.kc-repl.type-handler-load :as thl]
             [instaparse.core :as insta])
-  (:gen-class :name us.jeffevans.KcRepl))
+  (:gen-class))
 
 (defn- get-input-line []
   (read-line))
@@ -81,7 +81,7 @@
       (let [continue? (atom true)]
         (while @continue?
           (let [input       (get-input-line)
-                [op & args] (if (nil? input) ["stop"] (parse-line-as-cli-args input))
+                [op & args] (if (str/blank? input) ["stop"] (parse-line-as-cli-args input))
                 {:keys [::kcr/invoke-fn ::kcr/opts-spec ::kcr/print-offsets?]} (get @#'kcr/java-cmds op)]
             (log/tracef "got input %s, op %s, args %s, opts-spec %s" input op (pr-str args) (pr-str opts-spec))
             (println)

--- a/src/us/jeffevans/kc_repl/type_handler_load.clj
+++ b/src/us/jeffevans/kc_repl/type_handler_load.clj
@@ -16,8 +16,9 @@
     (require (symbol type-handler-ns))))
 
 (defn load-type-handlers []
-  (log/debug "trying to load type handlers from jars")
+  (log/debugf "trying to load type handlers from jars")
   (doseq [^JarFile jar-file (cp/classpath-jarfiles)]
+    (log/debugf "checking jar: %s" (.getName jar-file))
     (doseq [entry (-> (.entries jar-file)
                       enumeration-seq)]
       (when (= marker-file-nm (.getName entry))

--- a/test-common/src/us/jeffevans/kc_repl/test_containers.clj
+++ b/test-common/src/us/jeffevans/kc_repl/test_containers.clj
@@ -8,7 +8,7 @@
 
 (def tc-cfg (TestcontainersConfiguration/getInstance))
 
-(def ^:const cp-version "The Confluent Platform base version, to use for container images" "7.1.0")
+(def ^:const cp-version "The Confluent Platform base version, to use for container images" "7.2.0")
 
 (def zk-network-alias "zookeeper")
 

--- a/test/us/jeffevans/kc_repl_test.clj
+++ b/test/us/jeffevans/kc_repl_test.clj
@@ -136,5 +136,10 @@
                               ::kcr/reducing-fn      reducing-fn
                               ::kcr/map-record-fn    map-rec-fn})))
       (testing " and the new offset is correct (we should now be at offset 10 for test-topic:0)"
-        (is (= {(TopicPartition. "test-topic" 0) [10 true]} (kcr/current-assignments tc/*kcr-client*)))))))
+        (is (= {(TopicPartition. "test-topic" 0) [10 true]} (kcr/current-assignments tc/*kcr-client*))))
+      (testing " and we can unassign the test-topic:0 assignment and switch to test-topic:1"
+        ;; read from partition 1 to add that to active assignments
+        (kcr/read-from tc/*kcr-client* "test-topic" 1 0 1 "json")
+        (kcr/unassign tc/*kcr-client* "test-topic" 0)
+        (is (= {(TopicPartition. "test-topic" 1) [0 true]} (kcr/current-assignments tc/*kcr-client*)))))))
 

--- a/type-handlers/src/us/jeffevans/kc_repl/type_handlers.clj
+++ b/type-handlers/src/us/jeffevans/kc_repl/type_handlers.clj
@@ -1,5 +1,4 @@
-(ns us.jeffevans.kc-repl.type-handlers
-  (:gen-class :name us.jeffevans.KcRepl))
+(ns us.jeffevans.kc-repl.type-handlers)
 
 (defprotocol type-handler
              (parse-bytes [this ^String topic ^bytes b])


### PR DESCRIPTION
Various fixes and enhancements made in response to issues encountered when recording demos 😁 

* add `::kcr/key->clj?` and `::kcr/val->clj?` so that we can still get the ->clj data structure conversion in record mapping without a lot of fuss
* implement `unassign` operation to remove an active assignment
* various fixes to the `record-handling-opts` arg in many ops
* updating the `README.md` with new info on type handlers and linking to demos